### PR TITLE
Added beginning/end of line markers to help with databases that start…

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -70,8 +70,8 @@ crsctl stat res -v -w "TYPE = ora.database.type" >> $TMP
 		# Fill 2 tables with the OH and the version from "crsctl stat res -p -w "TYPE = ora.database.type""
 		if ($1 ~ /^NAME/)
                {
-			sub("ora.", "", $2)     								;
-			sub(".db", "", $2)      								;
+			sub("^ora.", "", $2)     								;
+			sub(".db$", "", $2)      								;
 			DB=$2                   								;
 							
 			getline; getline									;


### PR DESCRIPTION
… with "ora" or end with "db" in the db_name

This change fixed issues with databases called something like "mydb" in which case the cluster object name was "ora.mydb.db" and the current code was therefore reporting the dbname as just "my".